### PR TITLE
Model creation uses model.stub

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ You're all set. Run `php artisan` from the console, and you'll see the new comma
 ### Migrations With Schema
 
 ```
-php artisan make:migration:schema create_users_table --schema="username:string, email:string:unique"
+php artisan make:migration:schema create_users_table --schema="username:string:hidden, email:string:unique:fillable"
 ```
 
 Notice the format that we use, when declaring any applicable schema: a comma-separate list...
@@ -65,12 +65,14 @@ age:integer
 published_at:date
 excerpt:text:nullable
 email:string:unique:default('foo@example.com')
+
+Added hidden and fillable options to schema generation. This options are used when generating the model from model.stub file.
 ```
 
 Using the schema from earlier...
 
 ```
---schema="username:string, email:string:unique"
+--schema="username:string:hidden, email:string:unique:fillable"
 ```
 
 ...this will give you:
@@ -108,6 +110,35 @@ class CreateUsersTable extends Migration {
 		Schema::drop('users');
 	}
 
+}
+```
+
+```php
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'email',
+    ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'username',
+    ];
 }
 ```
 

--- a/src/Migrations/SchemaParser.php
+++ b/src/Migrations/SchemaParser.php
@@ -82,6 +82,12 @@ class SchemaParser
         $type = array_shift($segments);
         $arguments = [];
         $options = $this->parseOptions($segments);
+        $fillable = array_key_exists('fillable', $options);
+        if ($fillable)
+            unset($options['fillable']);
+        $hidden = array_key_exists('hidden', $options);
+        if ($hidden)
+            unset($options['hidden']);
 
         // Do we have arguments being used here?
         // Like: string(100)
@@ -90,7 +96,7 @@ class SchemaParser
             $arguments = explode(',', $matches[2]);
         }
 
-        return compact('name', 'type', 'arguments', 'options');
+        return compact('name', 'type', 'arguments', 'options', 'fillable', 'hidden');
     }
 
     /**

--- a/src/stubs/model.stub
+++ b/src/stubs/model.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class {{class}} extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        {{fillable}}
+    ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        {{hidden}}
+    ];
+}


### PR DESCRIPTION
Replaced current model creation to use model.stub as base file. Also
added hidden and fillable options to fields that are used to fill in the
$fillable and $hidden arrays in a model file.